### PR TITLE
#8 Update environment variable from museumos-prod to xos.

### DIFF
--- a/config.tmpl.env
+++ b/config.tmpl.env
@@ -1,4 +1,4 @@
-XOS_API_ENDPOINT=https://museumos-prod.acmi.net.au/api/
+XOS_API_ENDPOINT=https://xos.acmi.net.au/api/
 AUTH_TOKEN=
 XOS_PLAYLIST_ID=1
 SENTRY_ID=


### PR DESCRIPTION
*Resolves issue #8*

Rename references from museumos-prod to xos.

### Acceptance Criteria
- [x] Rename references from https://museumos-prod.acmi.net.au to https://xos.acmi.net.au

### Relevant design files
* None

### Testing instructions
1. Once XOS has been updated, restart this interactive label and see that it connects to XOS: https://dashboard.balena-cloud.com/apps/1522178/devices

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
