### PR TITLE
#38 Render title_annotation if present

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -35,6 +35,7 @@ const labels = window.data.playlist_labels.map(function playlist_labels_map(x) {
   return {
     id: x.label.id,
     title: x.label.title,
+    title_annotation: x.label.work ? x.label.work.title_annotation : null,
     publication: x.label.subtitles,
     description_column_1: x.label.columns[0].content,
     description_column_2: x.label.columns[1].content,
@@ -152,6 +153,16 @@ for (let i = 0; i < labels.length; i++) {
   left_col.appendChild(title);
   title.className = "modal_title";
   title.innerHTML = label.title;
+
+  if (label.title_annotation) {
+    const title_annotation = document.createElement("span");
+    title_annotation.className = "modal_title_annotation";
+    title_annotation.innerHTML = label.title_annotation;
+    title.innerHTML = title.innerHTML.replace(
+      /<\/p>/g,
+      `${title_annotation.outerHTML}</p>`
+    );
+  }
 
   const publication = document.createElement("div");
   left_col.appendChild(publication);

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -129,6 +129,13 @@ body {
   font-family: PxGrotesk;
 }
 
+.modal_title_annotation {
+  font-family: FaktPro;
+  font-size: 1.5rem;
+  padding-left: 0.6rem;
+  text-transform: lowercase;
+}
+
 .modal_publication {
   font-size: 18px;
   line-height: 25px;


### PR DESCRIPTION
Resolves #38

Display title_annotation if present based on designs from Pip.

### Acceptance Criteria
- [x] Implement css to display `title_annotation` field from the works serializer next to the Title, possibly with decoration such as square brackets.

### Relevant design files
* [Design from Pip](https://images.zenhubusercontent.com/5c56ba66fd8e3861b7794f29/c98cdcc4-b418-48c7-9b40-536d0b594ce7)

### Testing instructions
1. Edit `config.env` to point to `XOS_PLAYLIST_ID=46` and `XOS_API_ENDPOINT=https://xos.acmi.net.au/api/`
1. `cd development` and `docker-compose up --build`
1. Visit: http://localhost:8081 and tap the top left records
1. Note that `facsimile` is lowercased, and the size and spacing matches the design linked above

Sample from my development machine:

![Screen Shot 2020-06-25 at 3 28 48 pm](https://user-images.githubusercontent.com/314298/85660193-abe0c300-b6f8-11ea-8325-0d47b89073ca.png)

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
