### PR TITLE
#2070 Remove margin from bottom most p tag

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -351,7 +351,7 @@ p:first-child {
   margin-top: 0;
 }
 p:last-child {
-  margin-bottom: 0;
+  margin-bottom: 5px;
 }
 .error_screen {
   color: white;

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -350,6 +350,9 @@ body {
 p:first-child {
   margin-top: 0;
 }
+p:last-child {
+  margin-bottom: 0;
+}
 .error_screen {
   color: white;
 }

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 flake8
-isort
+isort<5
 pylint
 pytest
 pytest-flask


### PR DESCRIPTION
Resolves ACMILabs/xos#2070

- Removed the bottom margin from bottommost p element. 
- The top margin from the topmost element was already removed (thanks Simon!)

### Acceptance Criteria
- [x] CSS matches the design again

### Relevant design files
* In ACMILabs/xos#2070

### Testing instructions
1. Set `XOS_PLAYLIST_ID=46` in `config.env`
2. Spin up the spotlights locally: `cd development` and `docker-compose up`
3. Go to http://0.0.0.0:8081/ and check that the elements are aligned again

### DoD
For requester to complete:
- [X] All acceptance criteria are met
~New logic has been documented~
~New logic has appropriate unit tests~
~Changelog has been updated if necessary~
~Deployment / migration instruction have been updated if required~
