### PR TITLE
Sync css with XOS interactive label preview

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -41,6 +41,18 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+blockquote {
+  margin-left: 0;
+  margin-right: 0;
+  font-style: italic;
+}
+
+cite {
+  font-size: 0.8em;
+  font-style: normal;
+  font-weight: bold;
+}
+
 .background {
   background: #000 center/contain no-repeat;
   position: fixed;
@@ -350,8 +362,30 @@ body {
 p:first-child {
   margin-top: 0;
 }
+
 p:last-child {
   margin-bottom: 5px;
+}
+
+.child_work {
+  margin-bottom: 20px;
+}
+
+.child_work_title {
+  font-weight: bold;
+}
+
+.child_work_title_annotation {
+  font-size: 1.2rem;
+  text-transform: lowercase;
+}
+
+.child_work_subtitle {
+  font-size: 1.4rem;
+}
+
+.child_work_credit_line {
+  font-size: 1.4rem;
 }
 .error_screen {
   color: white;


### PR DESCRIPTION
Resolves ACMILabs/xos#2429

In the XOS codebase, changes were made that render hardcoded HTML into the interactive group label content. The hardcoded HTML broke the interactive-label display and the XOS interactive-label preview.

Then, some fixes were made directly to XOS interactive-label preview. The interactive-label codebase remained unchanged, and broken.

In order to continue work on the interactive group labels, we need to establish consistency between the group label content, playlist-label code, and XOS preview code.



### Acceptance Criteria
[x] Establishes consistency between group label content, playlist-label code, preview code.

### Relevant design files
* None

### Testing instructions
1. Ensure group labels look the same in XOS preview and interactive-label.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required

