### PR TITLE
#61 Revert sleep to 10 seconds after starting X, and also restart the container on failure

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -21,7 +21,7 @@ echo "Starting X"
 startx -- -nocursor &
 
 # TODO: work out how to detect X has started
-sleep 5
+sleep 10
 
 # Print all of the current displays used by running processes
 echo "Displays in use after starting X"
@@ -79,4 +79,8 @@ LIBVA_DRIVER_NAME=iHD chromium http://localhost:8081 \
 # For debugging
 echo "Chromium browser exited unexpectedly."
 free -h
+
+# Restart the container
+echo "Restarting container..."
+curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
 echo "End of x86.sh ..."


### PR DESCRIPTION
Resolves #61

Revert sleep to 10 seconds after starting X, and also restart the container on failure to avoid a boot looping condition.

### Acceptance Criteria
- [x] Catch failure to set `DISPLAY` on cold boot, restart container

### Relevant design files
* None

### Testing instructions
1. Reboot this device through Balena: [MI-02-LR06-PC01](https://dashboard.balena-cloud.com/devices/c691f677e755f72de7ba7a56715355df3b67e8f8314bca39eda66e38627c61/summary) and see that it boots successfully.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
