### PR TITLE
#69 fix label overflow

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -93,7 +93,7 @@ cite {
   transform: translateY(-50%);
   height: calc(100vh - 160px);
   left: 80px;
-  right: 80px;
+  width: 1760px;
   opacity: 0;
   pointer-events: none;
   overflow: auto;


### PR DESCRIPTION
Resolves #69

The image gallery is overflowing the label, wrapping to the next line.
This sets the label width in pixels instead of setting left and right margins to 80px.
By the way, this might mean the browser width isn't exactly 1920px.


### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] No acceptance criteria on the issue

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. None

### DoD
For requester to complete:
- [ ] All acceptance criteria are met
- [ ] New logic has been documented
- [ ] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- [ ] Deployment / migration instruction have been updated if required
