### PR TITLE
#75 autoclose after 1min

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -12,13 +12,15 @@ window.addEventListener('error', function (e) {
 })
 */
 
-let close_timer = null
+let close_timer = null;
 function handle_timer_timeout () {
-  close_modal()
+  if (current_modal) {
+    close_modal();
+  }
 }
 window.addEventListener('click', function () {
-  window.clearTimeout(close_timer)
-  close_timer = window.setTimeout(handle_timer_timeout, 60000)
+  window.clearTimeout(close_timer);
+  close_timer = window.setTimeout(handle_timer_timeout, 60000);
 })
 
 
@@ -119,6 +121,7 @@ function close_modal() {
   active_collect_element = null;
   active_path.classList.remove("active");
   active_path = null;
+  current_modal = null;
   save_label(null);
 }
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -12,18 +12,6 @@ window.addEventListener('error', function (e) {
 })
 */
 
-let close_timer = null;
-function handle_timer_timeout () {
-  if (current_modal) {
-    close_modal();
-  }
-}
-window.addEventListener('click', function () {
-  window.clearTimeout(close_timer);
-  close_timer = window.setTimeout(handle_timer_timeout, 60000);
-})
-
-
 function save_label(label_id) {
   // Save label selected to the local database for a tap
   fetch("http://localhost:8081/api/labels/", {
@@ -124,6 +112,17 @@ function close_modal() {
   current_modal = null;
   save_label(null);
 }
+
+let close_timer = null;
+function handle_timer_timeout() {
+  if (current_modal) {
+    close_modal();
+  }
+}
+window.addEventListener("click", function () {
+  window.clearTimeout(close_timer);
+  close_timer = window.setTimeout(handle_timer_timeout, 60000);
+});
 
 const modal_blind = document.createElement("div");
 modal_blind.className = "modal_blind";

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -12,6 +12,16 @@ window.addEventListener('error', function (e) {
 })
 */
 
+let close_timer = null
+function handle_timer_timeout () {
+  close_modal()
+}
+window.addEventListener('click', function () {
+  window.clearTimeout(close_timer)
+  close_timer = window.setTimeout(handle_timer_timeout, 60000)
+})
+
+
 function save_label(label_id) {
   // Save label selected to the local database for a tap
   fetch("http://localhost:8081/api/labels/", {


### PR DESCRIPTION
Resolves #75 

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] Automatically closes label modal after 60s
- [x] Clicking resets timer

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. Open a label modal, wait 60s, see that it closes
2. Open a label modal, wait, click, and see that it closes 60s after the click.

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required
