### PR TITLE
#81 handle calibration env var

### DIFF
--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -58,6 +58,11 @@ python -u app/main.py &
 # Wait for Flask to load
 sleep 5
 
+# Calibrate touch screen
+if [[ -v CALIBRATION ]]; then
+  xinput set-int-prop "eGalax Inc. USB TouchController Touchscreen" "Evdev Axis Calibration" $CALIBRATION
+fi
+
 LIBVA_DRIVER_NAME=iHD chromium http://localhost:8081 \
   --no-sandbox \
   --enable-native-gpu-memory-buffers --force-gpu-rasterization --enable-oop-rasterization --enable-zero-copy \

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -59,8 +59,8 @@ python -u app/main.py &
 sleep 5
 
 # Calibrate touch screen
-if [[ -v CALIBRATION ]]; then
-  xinput set-int-prop "eGalax Inc. USB TouchController Touchscreen" "Evdev Axis Calibration" $CALIBRATION
+if [[ -v TOUCH_CALIBRATION ]]; then
+  xinput set-int-prop "eGalax Inc. USB TouchController Touchscreen" "Evdev Axis Calibration" $TOUCH_CALIBRATION
 fi
 
 LIBVA_DRIVER_NAME=iHD chromium http://localhost:8081 \


### PR DESCRIPTION
Resolves #81

Allows an optional env var called $CALIBRATION, eg. 32 135 4096 5 4048.
Generate using:
xinput_calibration --output-type x_input

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] No acceptance criteria on the issue

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. None

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required
