### PR TITLE
#91 handle 2 taps within 100ms

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -149,8 +149,9 @@ def collect_item():
     Collect a tap and forward it on to XOS with the label ID.
     """
     has_tapped = HasTapped.get_or_none(has_tapped=0)
-    has_tapped.has_tapped = 1
-    has_tapped.save()
+    if has_tapped:
+        has_tapped.has_tapped = 1
+        has_tapped.save()
     xos_tap = dict(request.get_json())
     try:
         record = model_to_dict(Label.select().order_by(Label.datetime.desc()).get())


### PR DESCRIPTION
Resolves #91

Performs a null check to avoid crashing when tap reader noise hits the taps endpoint before our poll resets has_tapped.

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] No acceptance criteria on the issue

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. Tap multiple lenses/NFCs simultaneously

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required
