### PR TITLE
#95 fix auth cache

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -6,6 +6,7 @@ import requests
 import sentry_sdk
 
 XOS_API_ENDPOINT = os.getenv('XOS_API_ENDPOINT')
+AUTH_TOKEN = os.getenv('AUTH_TOKEN')
 XOS_PLAYLIST_ID = os.getenv('XOS_PLAYLIST_ID', '1')
 SENTRY_ID = os.getenv('SENTRY_ID')
 
@@ -50,8 +51,10 @@ def create_cache():
     Fetches a playlist, saves the images to the CACHE_DIR.
     """
     try:
+        headers = {'Authorization': 'Token ' + AUTH_TOKEN}
         playlist_json = requests.get(
             f'{XOS_API_ENDPOINT}playlists/{XOS_PLAYLIST_ID}/',
+            headers=headers,
             timeout=15,
         ).json()
 


### PR DESCRIPTION
Resolves #95

Uses auth token in playlists json request.
Fixes:
```
  File "app/cache.py", line 64, in create_cache
    for label in playlist_json['playlist_labels']:
KeyError: 'playlist_labels'
```

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] No acceptance criteria on the issue

### Relevant design files
Add a links to the relevant design files or leave as none.
* None

### Testing instructions
Add a list of steps required to test the feature.
1. Run app/cache.py successfully

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [x] Changelog has been updated if necessary
- [x] Deployment / migration instruction have been updated if required
