### PR TITLE
#112 Only show labels whose work is on display in the gallery

### DIFF
--- a/app/cache.py
+++ b/app/cache.py
@@ -54,6 +54,7 @@ def create_cache():
         headers = {'Authorization': 'Token ' + AUTH_TOKEN}
         playlist_json = requests.get(
             f'{XOS_API_ENDPOINT}playlists/{XOS_PLAYLIST_ID}/',
+            params={'not_on_display': 'false'},
             headers=headers,
             timeout=15,
         ).json()


### PR DESCRIPTION
Resolves #112

Use the `not_on_display` XOS Playlist API filter to remove Labels that aren't on display in the gallery.

### Acceptance Criteria
- [x] Use the `not_on_display=false` filter when requesting the Playlist from XOS

### Relevant design files
* None

### Testing instructions
1. Set your `config.env` to point at your local XOS on this branch: https://github.com/ACMILabs/xos/pull/2770
1. Start the interactive label: `cd development` and `docker-compose up`
1. Check the Interactive Label: http://localhost:8081
1. If its easier, examine the cached playlist in `/data/` noting that Labels whose Work is not on display don't show

### DoD
For requester to complete:
- [x] All acceptance criteria are met
~- [ ] New logic has been documented~
~- [ ] New logic has appropriate unit tests~
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
