### PR TITLE
#119 Fix black interactive label screens

### DIFF
--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -18,7 +18,9 @@ RUN install_packages \
   xinput \
   # Chinese character fonts
   fonts-arphic-ukai \
-  fonts-arphic-uming
+  fonts-arphic-uming \
+  # JQ for first boot checker
+  jq
 
 # disable lxpolkit popup warning
 RUN mv /usr/bin/lxpolkit /usr/bin/lxpolkit.bak

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -21,7 +21,9 @@ RUN install_packages \
   intel-media-va-driver \
   # Chinese character fonts
   fonts-arphic-ukai \
-  fonts-arphic-uming
+  fonts-arphic-uming \
+  # JQ for first boot checker
+  jq
 
 COPY ./conf/20-intel.conf /usr/share/X11/xorg.conf.d/20-intel.conf
 

--- a/scripts/first_boot.sh
+++ b/scripts/first_boot.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "________Start of first_boot.sh________"
+
+BOOT_COUNT_RESPONSE=$(curl -sk http://bootcount:8082/api/count/)
+BOOT_COUNT=$(echo $BOOT_COUNT_RESPONSE | jq --raw-output '.count')
+
+if [[ $BOOT_COUNT == "1" ]]; then
+  # Restart the container
+  echo "This is the first boot, so restarting the interactive label container in 30 seconds to resolve the background image turning black..."
+  sleep 30
+  # Update the boot count
+  curl --request POST 'http://bootcount:8082/api/count/'
+  # Restart the interactive label container
+  curl -H "Content-Type: application/json" -d "{\"serviceName\": \"$BALENA_SERVICE_NAME\"}" "$BALENA_SUPERVISOR_ADDRESS/v2/applications/$BALENA_APP_ID/restart-service?apikey=$BALENA_SUPERVISOR_API_KEY"
+else
+  echo "Boot count is $BOOT_COUNT so not restarting..."
+fi
+
+echo "________End of first_boot.sh________"

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -49,6 +49,11 @@ xset s off -dpms
 # Hide the cursor
 unclutter -idle 0.1 &
 
+# Start the first boot checker
+if [ -z "$DISABLE_FIRST_BOOT_CHECK" ]; then
+  ./scripts/first_boot.sh &
+fi
+
 # Cache playlist and images
 python -u -m app.cache
 


### PR DESCRIPTION
Resolves #119

Reported by Daniel Taylor today: https://helpdesk.acmi.net.au/browse/AHD-1831

> Interactive Screen Black, can select where an object would be and object screen comes up, once you click the back button it goes back to a Black Screen. After reboot it comes good, has been happening to all the Interactive Lens Reader Screens lately.

### Acceptance Criteria
Replace acceptance criteria with the acceptance criteria in the ticket or check the box if none.
- [x] Try re-starting the `interactivelabel` container on first boot to avoid background image turning black

### Relevant design files
* None

### Testing instructions
1. Add [bootcount](https://github.com/ACMILabs/s__spotlights-x86/blob/main/docker-compose.yml) container to [s__interactive-label-x86](https://github.com/ACMILabs/s__interactive-label-x86/blob/main/docker-compose.yml)
1. Push to devices and see if this avoids the black background image problem
