### PR TITLE
#133 Fix large text button doesn't wrap title text

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -136,9 +136,11 @@ cite {
 }
 
 .large_text_button_container {
-  float: right;
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 100;
   padding: 3rem;
-  margin-top: -3rem;
 }
 
 .large_text_button {


### PR DESCRIPTION
Resolves #133

The `large text` button currently makes long label titles wrap, so let's fix that.

### Acceptance Criteria
- [x] Position the large text button so it doesn't wrap label titles

### Relevant design files
* None

### Testing instructions
1. Set your `XOS_PLAYLIST_ID` to `41` or `42`
1. Run the label: `cd development` and `docker-compose up`
1. Note the title text doesn't wrap anymore: http://localhost:8081