### PR TITLE
#136 Update docker images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Build Python lint and test
       run: |
         cp config.tmpl.env config.env
-        cd development && docker-compose up --build -d
+        cd development && docker compose up --build -d
     - name: Run Python lint and test
       run: docker exec labelinteractive make linttest
 
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Javascript lint and test
       run: |
-        cd testing && docker-compose up --build -d
+        cd testing && docker compose up --build -d
         docker exec javascripttests make install
     - name: Run Javascript lint and test
       run: docker exec javascripttests make linttestjs

--- a/Dockerfile.raspberrypi4-64
+++ b/Dockerfile.raspberrypi4-64
@@ -1,6 +1,6 @@
 # base-image for python on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/
-FROM balenalib/raspberrypi3:buster
+FROM balenalib/raspberrypi3:bookworm
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 # base-image for python on any machine using a template variable,
 # see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/
-FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.7-buster-run
+FROM balenalib/%%BALENA_MACHINE_NAME%%-python:3.11-bookworm-run
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ Using your favourite graphics program, load up the background image for referenc
 * Run `cp config.tmpl.env config.env`
 * Edit `config.env` to include auth token for connecting to a playlist API
 * Run `cd development`
-* Run `docker-compose up --build`
+* Run `docker compose up --build`
 * Open a browser and visit: http://localhost:8081
 
 ## Run Javascript tests with docker
 
 * Run `cd testing`
-* Run `docker-compose up --build`
+* Run `docker compose up --build`
 * In another Terminal run `docker exec -it javascripttests make linttestjs`
 
 ## Run Python tests with docker
 
 * Run `cd development`
-* Run `docker-compose up --build`
+* Run `docker compose up --build`
 * In another Terminal run `docker exec -it labelinteractive make linttest`
 
 ## Run Python tests without docker

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/intel-nuc-python:3.7-buster-run
+FROM balenalib/intel-nuc-python:3.11-bookworm-run
 
 RUN install_packages apt-utils g++ build-essential
 


### PR DESCRIPTION
Resolves #136

Let's fix the build by updating docker images.

### Acceptance Criteria
- [x] Update to `3.11-bookworm` balenalib docker images

### Relevant design files
* None

### Testing instructions
1. Re-build: `cd development` and `docker compose up`
1. Note the labels still render: http://localhost:8081